### PR TITLE
Touches to the principal introduction to the UI

### DIFF
--- a/cocnept-designs/sean/injection.js
+++ b/cocnept-designs/sean/injection.js
@@ -13,7 +13,7 @@
 
     const demo = await new PrincipalDemo()
       .addTo(document.body)
-      .setThumbnail('../sean/former-principal.png', '#a8afae')
+      .setThumbnail('../../characters/sprites/images/munkler/sprite.png', '#a8afae')
       .start(json)
 
     demo.removeFromParent()

--- a/cocnept-designs/sean/intro.html
+++ b/cocnept-designs/sean/intro.html
@@ -413,7 +413,7 @@ Promise.all([
     intro.removeFromParent()
 
     // Simulate showing the Computer screen
-    window.location.href = '../v2/index.html?principal-demo=true'
+    window.location.href = './responsive.html?principal-demo=true'
   })
 
 /*

--- a/cocnept-designs/sean/principal-demo.css
+++ b/cocnept-designs/sean/principal-demo.css
@@ -37,7 +37,7 @@
   -webkit-appearance: none;
   border: none;
   background: none;
-  background-color: #222;
+  background-color: #666;
   cursor: pointer;
 }
 .demo-hide {

--- a/cocnept-designs/sean/principal-demo.css
+++ b/cocnept-designs/sean/principal-demo.css
@@ -10,7 +10,11 @@
   display: flex;
   align-items: center;
   max-width: 500px;
-  padding: 20px;
+  padding: 10px;
+  margin: 10px;
+  padding-right: 40px;
+  border-radius: 500px;
+  background-color: rgba(31, 31, 31, 0.8);
 }
 .demo-thumbnail {
   border: 5px solid var(--principal-highlight);
@@ -19,7 +23,9 @@
   border-radius: 50%;
   image-rendering: pixelated;
   object-fit: cover;
+  object-position: top;
   margin-right: 10px;
+  flex: none;
 }
 .demo-dialogue {
   flex: auto;

--- a/cocnept-designs/sean/principal-demo.json
+++ b/cocnept-designs/sean/principal-demo.json
@@ -1,5 +1,5 @@
 [
-  { "say": "You’ll be working here:" },
+  { "say": "You’ll be working here." },
   { "say": "This is the camera. You can click on students and our advanced facial recognition software will identify potential matches.", "select": "#camvis" },
   { "say": "Here you can switch camera views.", "select": "#camchoose" },
   { "say": "Here you can see our smoke detectors. These are designed to catch smoke from some newfangled “smile smokers” that kids have been using in the bathrooms.", "select": "#list > div:nth-child(7) > div.sinfo > p.sname" },

--- a/cocnept-designs/sean/responsive.html
+++ b/cocnept-designs/sean/responsive.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Suspension</title>
     <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
+    <script src="../sean/injection.js" charset="utf-8" type="module"></script>
     <style>
       @import url('https://fonts.googleapis.com/css?family=Inconsolata');
       * {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/22133785/81361428-390d8100-9093-11ea-9f41-0706583ebee4.png)

Resolves #11

- Added a background

- Uses the Munkler sprite image in /characters/sprites/images/

This also has some other changes:

- intro.html now redirects to responsive.html

- OK button is brightened for better contrast

- Colon after `You’ll be working here` replaced with full stop