### PR TITLE
Reduce intro bobbing

### DIFF
--- a/cocnept-designs/sean/intro.html
+++ b/cocnept-designs/sean/intro.html
@@ -41,10 +41,11 @@
 
       .speak-wrapper {
         padding: 20px;
+        box-sizing: border-box;
 
         display: flex;
         flex-direction: column;
-        width: 400px;
+        width: 440px;
       }
       .speak-thumbnail {
         border: 3px solid #a1a1a1;
@@ -107,6 +108,30 @@ const params = new URL(window.location).searchParams
  *   width (default 100)
  *   height (default 50)
  */
+
+function getAllDialogue (dialogue, defaultOption) {
+  const dialogueItems = []
+  if (!Array.isArray(dialogue)) {
+    dialogue = [dialogue]
+  }
+  for (let item of dialogue) {
+    if (typeof item === 'string') {
+      item = { say: item }
+    }
+    const { say = '', options, special = null } = item
+    dialogueItems.push({
+      say,
+      options: options ? Object.keys(options) : [defaultOption],
+      special
+    })
+    if (options) {
+      for (const option of Object.values(options)) {
+        dialogueItems.push(...getAllDialogue(option, defaultOption))
+      }
+    }
+  }
+  return dialogueItems
+}
 
 function * processDialogue (dialogue, defaultOption) {
   if (!Array.isArray(dialogue)) {
@@ -329,6 +354,47 @@ class SpeakIntroduction {
     }
   }
 
+  _setMaxHeight (dialogueData) {
+    const {
+      wrapper,
+      dialogue: dialogueText,
+      spoken,
+      toSpeak,
+      canvas
+    } = this.elems
+
+    wrapper.style.height = null
+    toSpeak.textContent = ''
+
+    let maxHeight = 0
+    for (const { say, options, special } of getAllDialogue(dialogueData, 'OK')) {
+      this._clearOptions()
+      for (const option of options) {
+        this._addOption(option)
+      }
+      spoken.textContent = say
+      let height
+      switch (special && special.type) {
+        case 'canvas': {
+          dialogueText.classList.add('speak-remove')
+          canvas.classList.remove('speak-remove')
+
+          ;({ height } = wrapper.getBoundingClientRect())
+
+          dialogueText.classList.remove('speak-remove')
+          canvas.classList.add('speak-remove')
+          break
+        }
+        default: {
+          ;({ height } = wrapper.getBoundingClientRect())
+        }
+      }
+      if (height > maxHeight) maxHeight = height
+    }
+
+    wrapper.style.height = maxHeight + 'px'
+  }
+
   async start (dialogueData) {
     const {
       dialogue: dialogueText,
@@ -336,6 +402,8 @@ class SpeakIntroduction {
       context,
       options: optionsWrapper
     } = this.elems
+
+    this._setMaxHeight(dialogueData)
 
     const dialogue = processDialogue(dialogueData, 'OK')
     const data = {}

--- a/cocnept-designs/sean/intro.html
+++ b/cocnept-designs/sean/intro.html
@@ -45,7 +45,8 @@
 
         display: flex;
         flex-direction: column;
-        width: 440px;
+        max-width: 440px;
+        width: 100%;
       }
       .speak-thumbnail {
         border: 3px solid #a1a1a1;
@@ -360,8 +361,16 @@ class SpeakIntroduction {
       dialogue: dialogueText,
       spoken,
       toSpeak,
-      canvas
+      canvas,
+      options: optionsWrapper
     } = this.elems
+
+    const old = {
+      spoken: spoken.textContent,
+      toSpeak: toSpeak.textContent,
+      buttons: [...optionsWrapper.children],
+      showingCanvas: !canvas.classList.contains('speak-remove')
+    }
 
     wrapper.style.height = null
     toSpeak.textContent = ''
@@ -393,6 +402,21 @@ class SpeakIntroduction {
     }
 
     wrapper.style.height = maxHeight + 'px'
+
+    // Recover old state if was in the middle of a conversation
+    ;({
+      spoken: spoken.textContent,
+      toSpeak: toSpeak.textContent
+    } = old)
+
+    this._clearOptions()
+    for (const button of old.buttons) {
+      optionsWrapper.appendChild(button)
+    }
+
+    if (old.showingCanvas) {
+      canvas.classList.remove('speak-remove')
+    }
   }
 
   async start (dialogueData) {
@@ -404,6 +428,10 @@ class SpeakIntroduction {
     } = this.elems
 
     this._setMaxHeight(dialogueData)
+    const remeasure = () => {
+      this._setMaxHeight(dialogueData)
+    }
+    window.addEventListener('resize', remeasure)
 
     const dialogue = processDialogue(dialogueData, 'OK')
     const data = {}
@@ -454,6 +482,7 @@ class SpeakIntroduction {
 
     }
 
+    window.removeEventListener('resize', remeasure)
     document.removeEventListener('keydown', this._onKeyDown)
 
     return data


### PR DESCRIPTION
Fixes #10

![image](https://user-images.githubusercontent.com/22133785/81451530-95c37700-9139-11ea-9da2-6722dff659c4.png)

Note: The image still shifts up/down when switching to the principal since it's a different conversation

Also makes the intro wrapper squishable on smaller screens