### PR TITLE
Optimize directory

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -53,7 +53,6 @@ rules:
         - error
         - max: 1
     no-multiple-empty-lines: error
-    no-negated-condition: error
     nonblock-statement-body-position:
         - error
         - beside

--- a/characters/sprites/sprite-cache.js
+++ b/characters/sprites/sprite-cache.js
@@ -1,21 +1,31 @@
-import {WIDTH, HEIGHT} from './sprite.js';
+import {SPRITE_WIDTH, SPRITE_HEIGHT, PICTURE_WIDTH, PICTURE_HEIGHT} from './sprite.js';
 
 // Add a pixel space between each sprite so thin slices of them don't appear
 const ENTRY_WIDTH = WIDTH + 1;
 
 export class SpriteCache {
-    constructor(capacity) {
+    constructor(capacity, type='sprite') {
         if (!Number.isInteger(capacity)) {
             throw new TypeError('Capacity should be an integer.');
         }
+        if (type === 'sprite') {
+            this.width = SPRITE_WIDTH;
+            this.height = SPRITE_HEIGHT;
+        } else if (type === 'picture') {
+            this.width = PICTURE_WIDTH;
+            this.height = PICTURE_HEIGHT;
+        } else {
+            throw new Error('Type should be either "sprite" or "picture".');
+        }
+        this.entryWidth = this.width + 1;
 
         this.capacity = capacity;
         this.sprites = 0;
 
         this._canvas = document.createElement('canvas');
         this._context = this._canvas.getContext('2d');
-        this._canvas.width = capacity * ENTRY_WIDTH - 1;
-        this._canvas.height = HEIGHT;
+        this._canvas.width = capacity * this.entryWidth - 1;
+        this._canvas.height = this.height;
     }
 
     canAdd() {
@@ -27,17 +37,17 @@ export class SpriteCache {
             throw new Error('Cache is full and cannot accept any more students.');
         }
         let spriteId = this.sprites++;
-        this._context.drawImage(sprite, spriteId * ENTRY_WIDTH, 0);
+        this._context.drawImage(sprite, spriteId * this.entryWidth, 0);
         return spriteId;
     }
 
-    draw(context, spriteId, x=0, y=0, width=WIDTH, height=HEIGHT) {
+    draw(context, spriteId, x=0, y=0, width=this.width, height=this.height) {
         context.drawImage(
             this._canvas,
-            spriteId * ENTRY_WIDTH,
+            spriteId * this.entryWidth,
             0,
-            WIDTH,
-            HEIGHT,
+            this.width,
+            this.height,
             x,
             y,
             width,

--- a/characters/sprites/sprite-cache.js
+++ b/characters/sprites/sprite-cache.js
@@ -1,8 +1,5 @@
 import {SPRITE_WIDTH, SPRITE_HEIGHT, PICTURE_WIDTH, PICTURE_HEIGHT} from './sprite.js';
 
-// Add a pixel space between each sprite so thin slices of them don't appear
-const ENTRY_WIDTH = WIDTH + 1;
-
 export class SpriteCache {
     constructor(capacity, type='sprite') {
         if (!Number.isInteger(capacity)) {
@@ -17,6 +14,7 @@ export class SpriteCache {
         } else {
             throw new Error('Type should be either "sprite" or "picture".');
         }
+        // Add a pixel between each entry to prevent pixel bleeding.
         this.entryWidth = this.width + 1;
 
         this.capacity = capacity;

--- a/characters/sprites/sprite.js
+++ b/characters/sprites/sprite.js
@@ -50,7 +50,7 @@ function loadImages() {
 function drawTinted(image, y, facing, cuts) {
     cuts.push(23);
     for (let i = 0; i < cuts.length; i++) {
-        ctx.drawImage(image, 0, cuts[i - 1] || 0, WIDTH, cuts[i] - (cuts[i - 1] || 0) + 1, 0, (cuts[i - 1] || 0) + y + i, facing * WIDTH, cuts[i] - (cuts[i - 1] || 0) + 1);
+        ctx.drawImage(image, 0, cuts[i - 1] || 0, SPRITE_WIDTH, cuts[i] - (cuts[i - 1] || 0) + 1, 0, (cuts[i - 1] || 0) + y + i, facing * SPRITE_WIDTH, cuts[i] - (cuts[i - 1] || 0) + 1);
     }
 }
 
@@ -61,7 +61,7 @@ function getSprite(sprite, picture=false) {
     }
 
     ctx.save();
-    ctx.clearRect(0, 0, WIDTH, HEIGHT);
+    ctx.clearRect(0, 0, SPRITE_WIDTH, SPRITE_HEIGHT);
     ctx.scale(sprite.facing, 1);
 
     let cuts = [];
@@ -84,7 +84,7 @@ function getSprite(sprite, picture=false) {
         drawTinted(images.hats, 3 - sprite.height, sprite.facing, []);
     }
 
-    let gid = ctx.getImageData(0, 0, WIDTH, HEIGHT);
+    let gid = ctx.getImageData(0, 0, SPRITE_WIDTH, SPRITE_HEIGHT);
 
     for (let i = 0; i < gid.data.length; i += 4) {
         let id = [];

--- a/characters/sprites/sprite.js
+++ b/characters/sprites/sprite.js
@@ -1,16 +1,18 @@
 let loaded = 0;
-const WIDTH = 12; // leaving these here because Sean might use em
-const HEIGHT = 27; // these are the dimensions of the normal sprite, not the picture
+const SPRITE_WIDTH = 12; // leaving these here because Sean might use em
+const SPRITE_HEIGHT = 27; // these are the dimensions of the normal sprite, not the picture
 
+const PICTURE_WIDTH = 16;
+const PICTURE_HEIGHT = 16;
 
 let out = document.createElement('canvas');
-out.width = WIDTH;
-out.height = HEIGHT;
+out.width = SPRITE_WIDTH;
+out.height = SPRITE_HEIGHT;
 let ctx = out.getContext('2d');
 
 let pout = document.createElement('canvas');
-pout.width = 16;
-pout.height = 16;
+pout.width = PICTURE_WIDTH;
+pout.height = PICTURE_HEIGHT;
 let pctx = pout.getContext('2d');
 
 let paths = [
@@ -53,11 +55,11 @@ function drawTinted(image, y, facing, cuts) {
 }
 
 function getSprite(sprite, picture=false) {
-    
+
     if (picture) {
         pctx.drawImage(images.picture, 0, 0);
     }
-    
+
     ctx.save();
     ctx.clearRect(0, 0, WIDTH, HEIGHT);
     ctx.scale(sprite.facing, 1);
@@ -66,7 +68,7 @@ function getSprite(sprite, picture=false) {
     for (let i = 0; i < sprite.height; i++) {
         cuts.push(i === sprite.height - 1 && i !== 0 ? 22 : 15);
     }
-    
+
     drawTinted(images.skin, 3 - sprite.height, sprite.facing, cuts);
     if (!picture) {
         drawTinted(images['pants' + sprite.pants.type], 3 - sprite.height, sprite.facing, cuts);
@@ -127,7 +129,7 @@ function getSprite(sprite, picture=false) {
 
     ctx.putImageData(gid, 0, 0);
     ctx.restore();
-    
+
     if (picture) {
         pctx.drawImage(out, 2, 0);
         return pout;
@@ -136,8 +138,14 @@ function getSprite(sprite, picture=false) {
 }
 
 export {
-    WIDTH,
-    HEIGHT,
+    SPRITE_WIDTH,
+    SPRITE_HEIGHT,
+    PICTURE_WIDTH,
+    PICTURE_HEIGHT,
     loadImages,
-    getSprite
+    getSprite,
+
+    // Just in case??
+    SPRITE_WIDTH as WIDTH,
+    SPRITE_HEIGHT as HEIGHT
 };

--- a/characters/sprites/sprite.js
+++ b/characters/sprites/sprite.js
@@ -47,6 +47,17 @@ function loadImages() {
     })));
 }
 
+// If more than one parts of the code call loadImages() directly, some images
+// fail to render properly initially. I think it's because the newer one
+// overwrites images[code] with a new Image that needs to be loaded
+let imagesLoaded;
+function loadImagesSafely() {
+    if (!imagesLoaded) {
+        imagesLoaded = loadImages();
+    }
+    return imagesLoaded;
+}
+
 function drawTinted(image, y, facing, cuts) {
     cuts.push(23);
     for (let i = 0; i < cuts.length; i++) {
@@ -142,7 +153,7 @@ export {
     SPRITE_HEIGHT,
     PICTURE_WIDTH,
     PICTURE_HEIGHT,
-    loadImages,
+    loadImagesSafely as loadImages,
     getSprite,
 
     // Just in case??

--- a/characters/sprites/sprite.js
+++ b/characters/sprites/sprite.js
@@ -1,4 +1,3 @@
-let loaded = 0;
 const SPRITE_WIDTH = 12; // leaving these here because Sean might use em
 const SPRITE_HEIGHT = 27; // these are the dimensions of the normal sprite, not the picture
 
@@ -32,7 +31,7 @@ let images = {};
 function loadImages() {
     return Promise.all(paths.map(path => new Promise(resolve => {
         let img = new Image();
-        img.crossOrigin = "Anonymous";
+        img.crossOrigin = 'Anonymous';
         img.src = new URL(`./images/student/${path}.png`, import.meta.url);
         img.onload = resolve;
 
@@ -66,7 +65,6 @@ function drawTinted(image, y, facing, cuts) {
 }
 
 function getSprite(sprite, picture=false) {
-
     if (picture) {
         pctx.drawImage(images.picture, 0, 0);
     }
@@ -84,7 +82,7 @@ function getSprite(sprite, picture=false) {
     if (!picture) {
         drawTinted(images['pants' + sprite.pants.type], 3 - sprite.height, sprite.facing, cuts);
         drawTinted(images['shoes' + sprite.shoes.type], 3, sprite.facing, []);
-    };
+    }
     drawTinted(images['shirt' + sprite.shirt.type], 3 - sprite.height, sprite.facing, cuts);
     drawTinted(images.shadow, 3 - sprite.height, sprite.facing, cuts);
     drawTinted(images['hair' + sprite.hair.type], 3 - sprite.height, sprite.facing, cuts);
@@ -135,7 +133,6 @@ function getSprite(sprite, picture=false) {
         gid.data[i] = Math.max(0, rgb[0] - (255 - base));
         gid.data[i + 1] = Math.max(0, rgb[1] - (255 - base));
         gid.data[i + 2] = Math.max(0, rgb[2] - (255 - base));
-
     }
 
     ctx.putImageData(gid, 0, 0);

--- a/cocnept-designs/v2/directory.js
+++ b/cocnept-designs/v2/directory.js
@@ -198,14 +198,14 @@ class Directory {
         // An array containing items that are no longer visible
         // This also removes them from this._items
         let recycleables = [...this._items]
-            .filter(([y, item]) => {
+            .filter(([y]) => {
                 if (typeof y !== 'number' || y < start || y >= stop) {
                     this._items.delete(y);
                     return true;
                 }
                 return false;
             })
-            .map(([_, item]) => item);
+            .map(pair => pair[1]);
         for (let y = start; y < stop; y++) {
             // Do not show DirectoryItems that are out of bounds
             if (y < 0 || y >= this.students.length) continue;

--- a/cocnept-designs/v2/directory.js
+++ b/cocnept-designs/v2/directory.js
@@ -1,0 +1,196 @@
+import {bindMethods} from '../../utils.js';
+import {PICTURE_WIDTH, PICTURE_HEIGHT} from '../../characters/sprites/sprite.js';
+
+/**
+ * Represents a DOM element in the directory.
+ */
+class DirectoryItem {
+    constructor() {
+        bindMethods(this, [
+            '_onClick'
+        ]);
+
+        this._parent = null;
+        this._makeElements();
+    }
+
+    _makeElements() {
+        let wrapper = document.createElement('div');
+        wrapper.classList.add('student');
+        wrapper.addEventListener('click', this._onClick);
+
+        let picwrap = document.createElement('div');
+        picwrap.classList.add('spic');
+        wrapper.appendChild(picwrap);
+
+        let pic = document.createElement('canvas');
+        picwrap.classList.add('spic-canvas');
+        pic.width = PICTURE_WIDTH;
+        pic.height = PICTURE_HEIGHT;
+        let ctx = pic.getContext('2d');
+        ctx.imageSmoothingEnabled = false;
+        picwrap.appendChild(pic);
+
+        let infowrap = document.createElement('div');
+        infowrap.classList.add('sinfo');
+        wrapper.appendChild(infowrap);
+
+        let name = document.createElement('p');
+        name.classList.add('sname');
+        infowrap.appendChild(name);
+
+        let info = document.createElement('p');
+        infowrap.appendChild(info);
+
+        this._elems = {
+            wrapper,
+            ctx,
+            name,
+            info
+        };
+    }
+
+    get wrapper() {
+        return this._elems.wrapper;
+    }
+
+    _onClick() {
+        if (selElement) {
+            selElement.classList.remove('selected');
+        }
+
+        if (getSchedule(student)) {
+            selElement = wrapper;
+            selElement.classList.add('selected');
+        }
+    }
+
+    setStudent(student) {
+        let {wrapper, ctx, name, info} = this._elems;
+        wrapper.id = student.id;
+        // TODO: Cache student pictures
+        ctx.drawImage(SPRITES.getSprite(student.picture, true), 0, 0, PICTURE_WIDTH, PICTURE_HEIGHT);
+        name.innerHTML = `${student.name.last}, ${student.name.first}`;
+        info.innerHTML = `Grade ${disgrade} | ${student.gender} | <span class="sstatus">Enrolled</span>`;
+    }
+
+    // Note: Pass null to remove.
+    addTo(parent=null) {
+        if (parent !== this._parent) {
+            if (this._parent) {
+                this._parent.removeChild(this._elems.wrapper);
+            }
+            this._parent = parent;
+            if (parent) {
+                parent.appendChild(this._elems.wrapper);
+            }
+        }
+        return this;
+    }
+
+    remove() {
+        this.addTo(null);
+        return this;
+    }
+}
+
+// TODO: Get this dynamically?
+// Visual height of each item in pixels
+const ITEM_HEIGHT = 72;
+
+// Extra items to have ready to show above and below (both sides, so additional
+// items is double the constant) the list so the items seem to come in an instant.
+const ITEM_PADDING = 2;
+
+/**
+ * Recycles DirectoryItems as the user scrolls to limit the number of elements.
+ */
+class Directory {
+    constructor(wrapper, students=[]) {
+        bindMethods(this, [
+            'updateScroll'
+        ]);
+
+        this.wrapper = wrapper;
+        this.students = students;
+
+        // Maps y values/a unique Symbol (if not shown) to a DirectoryItem
+        this._items = new Map();
+
+        // A dummy element to set the scroll height
+        this._heightSetter = document.createElement('div');
+        this._heightSetter.className = 'height-setter';
+
+        this.wrapper.addEventListener('scroll', this.updateScroll);
+    }
+
+    _clearItems() {
+        for (let item of this._items.values()) {
+            item.remove();
+        }
+        this._items.clear();
+    }
+
+    _generateItems() {
+        // Imagine that the visible list
+        const itemCount = Math.ceil(this.height / ITEM_HEIGHT) + 1 + ITEM_PADDING * 2;
+        for (let i = 0; i < itemCount; i++) {
+            // Symbol() just means that it hasn't been assigned a y-value
+            this._items.set(Symbol(), new DirectoryItem());
+        }
+    }
+
+    updateScroll() {
+        let scrollY = this.wrapper.scrollTop;
+        let start = Math.floor(scrollY / ITEM_HEIGHT) - ITEM_PADDING;
+        let stop = Math.ceil((scrollY + this.height) / ITEM_HEIGHT) + ITEM_PADDING;
+        // An array containing items that are no longer visible
+        // This also removes them from this._items
+        let recycleables = [...this._items]
+            .filter(([y, item]) => {
+                if (typeof y !== 'number' || y < start || y >= stop) {
+                    this._items.delete(y);
+                    return true;
+                }
+                return false;
+            })
+            .map(([_, item]) => item);
+        for (let y = start; y < stop; y++) {
+            // Do not show DirectoryItems that are out of bounds
+            if (y < 0 || y >= this.students.length) continue;
+            // If an item is already at this position, leave it.
+            if (this._items.has(y)) continue;
+
+            // Move a recycleable to the unclaimed position
+            let recycleable = recycleables.pop();
+            recycleable
+                .addTo(this.wrapper)
+                .wrapper.style.top = y * ITEM_HEIGHT + 'px';
+            this._items.set(y, recycleable);
+        }
+        // Hide the rest
+        for (let recycleable of recycleables) {
+            recycleable.remove();
+            this._items.set(Symbol(), recycleable);
+        }
+        return this;
+    }
+
+    async resize(then=Promise.resolve()) {
+        let {height} = this.wrapper.getBoundingClientRect();
+        await then;
+        this.height = height;
+        this._generateItems();
+        return this;
+    }
+
+    // Call this when `this.students` is changed.
+    updateData() {
+        this._heightSetter.style.height = this.students.length * ITEM_HEIGHT + 'px';
+        this.updateScroll();
+    }
+}
+
+export {
+    Directory
+};

--- a/cocnept-designs/v2/directory.js
+++ b/cocnept-designs/v2/directory.js
@@ -127,11 +127,23 @@ class Directory {
         wrapper.addEventListener('scroll', this.updateScroll);
     }
 
-    _clearItems() {
+    // Deletes all DirectoryItems
+    _deleteItems() {
         for (let item of this._items.values()) {
             item.remove();
         }
         this._items.clear();
+    }
+
+    // Simply removes all visible DirectoryItems from the list
+    _hideItems() {
+        for (let [y, item] of this._items) {
+            if (typeof y === 'number') {
+                this._items.delete(y);
+                item.remove();
+                this._items.set(Symbol(), item);
+            }
+        }
     }
 
     _generateItems() {
@@ -184,6 +196,7 @@ class Directory {
         let {height} = this.wrapper.getBoundingClientRect();
         await then;
         this.height = height;
+        this._deleteItems();
         this._generateItems();
         return this;
     }
@@ -191,6 +204,7 @@ class Directory {
     // Call this when `this.students` is changed. Will not call updateScroll.
     updateData() {
         this._heightSetter.style.height = this.students.length * ITEM_HEIGHT + 'px';
+        this._hideItems();
     }
 }
 

--- a/cocnept-designs/v2/directory.js
+++ b/cocnept-designs/v2/directory.js
@@ -1,5 +1,5 @@
 import {bindMethods} from '../../utils.js';
-import {PICTURE_WIDTH, PICTURE_HEIGHT} from '../../characters/sprites/sprite.js';
+import {PICTURE_WIDTH, PICTURE_HEIGHT, getSprite} from '../../characters/sprites/sprite.js';
 
 /**
  * Represents a DOM element in the directory.
@@ -24,7 +24,7 @@ class DirectoryItem {
         wrapper.appendChild(picwrap);
 
         let pic = document.createElement('canvas');
-        picwrap.classList.add('spic-canvas');
+        pic.classList.add('spic-canvas');
         pic.width = PICTURE_WIDTH;
         pic.height = PICTURE_HEIGHT;
         let ctx = pic.getContext('2d');
@@ -69,9 +69,11 @@ class DirectoryItem {
         let {wrapper, ctx, name, info} = this._elems;
         wrapper.id = student.id;
         // TODO: Cache student pictures
-        ctx.drawImage(SPRITES.getSprite(student.picture, true), 0, 0, PICTURE_WIDTH, PICTURE_HEIGHT);
+        ctx.drawImage(getSprite(student.picture, true), 0, 0, PICTURE_WIDTH, PICTURE_HEIGHT);
         name.innerHTML = `${student.name.last}, ${student.name.first}`;
+        let disgrade = student.grade === 9 ? '09' : student.grade;
         info.innerHTML = `Grade ${disgrade} | ${student.gender} | <span class="sstatus">Enrolled</span>`;
+        return this;
     }
 
     // Note: Pass null to remove.
@@ -120,8 +122,9 @@ class Directory {
         // A dummy element to set the scroll height
         this._heightSetter = document.createElement('div');
         this._heightSetter.className = 'height-setter';
+        wrapper.appendChild(this._heightSetter);
 
-        this.wrapper.addEventListener('scroll', this.updateScroll);
+        wrapper.addEventListener('scroll', this.updateScroll);
     }
 
     _clearItems() {
@@ -164,6 +167,7 @@ class Directory {
             // Move a recycleable to the unclaimed position
             let recycleable = recycleables.pop();
             recycleable
+                .setStudent(this.students[y])
                 .addTo(this.wrapper)
                 .wrapper.style.top = y * ITEM_HEIGHT + 'px';
             this._items.set(y, recycleable);
@@ -184,10 +188,9 @@ class Directory {
         return this;
     }
 
-    // Call this when `this.students` is changed.
+    // Call this when `this.students` is changed. Will not call updateScroll.
     updateData() {
         this._heightSetter.style.height = this.students.length * ITEM_HEIGHT + 'px';
-        this.updateScroll();
     }
 }
 

--- a/cocnept-designs/v2/index.html
+++ b/cocnept-designs/v2/index.html
@@ -364,6 +364,7 @@
             import * as SCHOOL from '../../school/school.js';
             import * as SCHEDULE from '../../school/schedule.js';
             import * as SPRITES from '../../characters/sprites/sprite.js';
+            import {Directory} from './directory.js';
 
             // Toggle panel buttons for small screen
             let togglePanelBtns = document.getElementsByClassName('toggle-panel-btn');
@@ -407,6 +408,7 @@
             let school;
             let selected = 0;
             let selElement;
+            let directoryList = new Directory(document.getElementById('list'));
 
             async function dewit() {
                 await SPRITES.loadImages();
@@ -415,9 +417,9 @@
 
                 school.Students.sort((x, y) => x.name.last.localeCompare(y.name.last));
 
-                for (let i = 0; i < school.Students.length; i++) {
-                    addStudent(school.Students[i]);
-                }
+                directoryList.students = school.Students;
+                await directoryList.resize();
+                directoryList.updateScroll();
             }
 
             function search(name) {

--- a/cocnept-designs/v2/index.html
+++ b/cocnept-designs/v2/index.html
@@ -417,19 +417,21 @@
 
                 school.Students.sort((x, y) => x.name.last.localeCompare(y.name.last));
 
-                directoryList.students = school.Students;
+                directoryList.students = [...school.Students];
                 directoryList.updateData();
                 await directoryList.resize();
                 directoryList.updateScroll();
             }
 
             function search(name) {
-                for (let i = 0; i < school.Students.length; i++) {
-                    let student = school.Students[i];
-
-                    let match = `${student.name.last}, ${student.name.first}`.toLowerCase().includes(name.toLowerCase());
-                    document.getElementById(student.id).style.display = match ? 'flex' : 'none';
-                }
+                directoryList.students = school.Students
+                    .filter(student => {
+                        return `${student.name.last}, ${student.name.first}`
+                            .toLowerCase()
+                            .includes(name.toLowerCase());
+                    });
+                directoryList.updateData();
+                directoryList.updateScroll();
             }
 
             function getSchedule(student) {

--- a/cocnept-designs/v2/index.html
+++ b/cocnept-designs/v2/index.html
@@ -418,6 +418,7 @@
                 school.Students.sort((x, y) => x.name.last.localeCompare(y.name.last));
 
                 directoryList.students = school.Students;
+                directoryList.updateData();
                 await directoryList.resize();
                 directoryList.updateScroll();
             }

--- a/cocnept-designs/v2/index.html
+++ b/cocnept-designs/v2/index.html
@@ -434,22 +434,23 @@
                 directoryList.updateScroll();
             }
 
-            function getSchedule(student) {
-                if (student.id === selected) {
-                    return getSchedule({schedule: [{}, {}, {}, {}, {}, {}]});
-                }
-
-                let schedule = student.schedule;
-
+            let emptySchedule = [{}, {}, {}, {}, {}, {}];
+            function displaySchedule(schedule=emptySchedule) {
                 for (let i = 0; i < 6; i++) {
                     let row = document.getElementById('tlist' + i);
-                    let clase = student.name ? schedule[i].name || 'IDENTITY' : '';
+                    //Intrapersonal Discipline and Educational Nurturing for Teaching Information to Teenaged Youth
+                    let clase = schedule !== emptySchedule ? schedule[i].name || 'IDENTITY' : '';
                     row.innerHTML = `<p>${'ABCDEF'[i]}</p><p>${clase}</p><p>${(schedule[i].room + 1) || ''}</p>`;
-                }//Intrapersonal Discipline and Educational Nurturing for Teaching Information to Teenaged Youth
-
-                selected = student.id || 0;
-                return selected !== 0;
+                }
             }
+
+            directoryList.onSelect = student => {
+                if (student) {
+                    displaySchedule(student.schedule);
+                } else {
+                    displaySchedule();
+                }
+            };
 
             function addStudent(student) {
                 let wrapper = document.createElement('div');
@@ -501,7 +502,7 @@
             changeMenu('unmenu');
 
             dewit();
-            getSchedule({schedule: [{}, {}, {}, {}, {}, {}]});
+            displaySchedule();
 
             const searchInput = document.getElementById('search');
             searchInput.addEventListener('input', e => {

--- a/cocnept-designs/v2/index.html
+++ b/cocnept-designs/v2/index.html
@@ -406,8 +406,6 @@
 
             // Student directory
             let school;
-            let selected = 0;
-            let selElement;
             let directoryList = new Directory(document.getElementById('list'));
 
             async function dewit() {
@@ -452,51 +450,11 @@
                 }
             };
 
-            function addStudent(student) {
-                let wrapper = document.createElement('div');
-                wrapper.classList.add('student');
-                wrapper.id = student.id;
-                wrapper.addEventListener('click', function() {
-                    if (selElement) {
-                        selElement.classList.remove('selected');
-                    }
-
-                    if (getSchedule(student)) {
-                        selElement = wrapper;
-                        selElement.classList.add('selected');
-                    }
-                });
-                document.getElementById('list').appendChild(wrapper);
-
-                let picwrap = document.createElement('div');
-                picwrap.classList.add('spic');
-                wrapper.appendChild(picwrap);
-
-                let pic = document.createElement('canvas');
-                pic.style.width = '50px';
-                pic.style.height = '50px';
-                pic.width = 50 * window.devicePixelRatio;
-                pic.height = 50 * window.devicePixelRatio;
-                let ctx = pic.getContext('2d');
-                ctx.imageSmoothingEnabled = false;
-                ctx.scale(window.devicePixelRatio, window.devicePixelRatio);
-                ctx.drawImage(SPRITES.getSprite(student.picture, true), 0, 0, 50, 50);
-                picwrap.appendChild(pic);
-
-                let infowrap = document.createElement('div');
-                infowrap.classList.add('sinfo');
-                wrapper.appendChild(infowrap);
-
-                let name = document.createElement('p');
-                name.classList.add('sname');
-                name.innerHTML = `${student.name.last}, ${student.name.first}`;
-                infowrap.appendChild(name);
-
-                let info = document.createElement('p');
-                let disgrade = student.grade === 9 ? '09' : student.grade;
-                info.innerHTML = `Grade ${disgrade} | ${student.gender} | <span class="sstatus">Enrolled</span>`;
-                infowrap.appendChild(info);
-            }
+            // TODO: Breaks if the user resizes while on the office screens
+            window.addEventListener('resize', async () => {
+                await directoryList.resize();
+                directoryList.updateScroll();
+            });
 
             switchScreen('game');
             changeMenu('unmenu');

--- a/cocnept-designs/v2/index.html
+++ b/cocnept-designs/v2/index.html
@@ -369,7 +369,7 @@
             // Toggle panel buttons for small screen
             let togglePanelBtns = document.getElementsByClassName('toggle-panel-btn');
             for (let btn of togglePanelBtns) {
-                btn.addEventListener('click', e => {
+                btn.addEventListener('click', () => {
                     document.body.classList.toggle('show-right-panel');
                     if (document.body.classList.contains('show-right-panel')) {
                         for (let btn of togglePanelBtns) btn.textContent = '<';
@@ -436,7 +436,7 @@
             function displaySchedule(schedule=emptySchedule) {
                 for (let i = 0; i < 6; i++) {
                     let row = document.getElementById('tlist' + i);
-                    //Intrapersonal Discipline and Educational Nurturing for Teaching Information to Teenaged Youth
+                    // Intrapersonal Discipline and Educational Nurturing for Teaching Information to Teenaged Youth
                     let clase = schedule !== emptySchedule ? schedule[i].name || 'IDENTITY' : '';
                     row.innerHTML = `<p>${'ABCDEF'[i]}</p><p>${clase}</p><p>${(schedule[i].room + 1) || ''}</p>`;
                 }
@@ -463,7 +463,7 @@
             displaySchedule();
 
             const searchInput = document.getElementById('search');
-            searchInput.addEventListener('input', e => {
+            searchInput.addEventListener('input', () => {
                 search(searchInput.value);
             });
 

--- a/cocnept-designs/v2/styles.css
+++ b/cocnept-designs/v2/styles.css
@@ -192,19 +192,27 @@
     padding: 0;
 }
 .student {
+    position: absolute;
+    width: 100%;
     align-items: center;
     border-top: 2px solid #222;
     cursor: pointer;
     display: flex;
     margin: 0 10px;
     padding: 10px 0;
-    transition: 0.1s;
+    transition: background-color 0.1s;
 }
 .spic {
     background-color: aliceblue; /* this should not show */
     height: 50px;
     margin-right: 10px;
     width: 50px;
+}
+.spic-canvas {
+    image-rendering: crisp-edges;
+    image-rendering: pixelated;
+    width: 100%;
+    height: 100%;
 }
 .sinfo {
     display: flex;

--- a/cocnept-designs/v2/styles.css
+++ b/cocnept-designs/v2/styles.css
@@ -193,7 +193,8 @@
 }
 .student {
     position: absolute;
-    width: 100%;
+    left: 0;
+    right: 0;
     align-items: center;
     border-top: 2px solid #222;
     cursor: pointer;


### PR DESCRIPTION
Fixes #44 

Putting like a thousand elements in that huge list is probably not a good idea, so this uses the concept of RECYCLING elements to reduce the number of elements in the DOM.

This PR is also LINTED, which is very epic. It also fixes a catastrophe that may occur when two things both call `SPRITE.loadImages`.

Currently, the list (and camera with students roaming) can be broken by resizing the window with the Office screen open. This I feel is a separate issue and could be solved with either:

- A centralized resize system that can create a promise to call `.resize` when the person switches to the Computer screen
    - This has the added benefit of allowing the camera to stop rendering when the person switches over to the Office screen
    - This can also be good for performance in a different way: My `.resize` methods accept a promise so that they can all perform measurements together, then resize accordingly together. This prevents a forced relayout/repaint, which occurs if you call something that measures the size of something after editing the DOM
- A way simpler solution would be to `position: fixed/absolute;` the hidden screen with `opacity: 0;` and `pointer-events: none;` (or `visibility: hidden;`) so that the sizes are still rendered