### PR TITLE
Create sprite images in web worker

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -21,7 +21,6 @@ rules:
     semi:
         - error
         - always
-    require-atomic-updates: error
     default-case-last: error
     default-param-last: error
     curly:
@@ -73,6 +72,8 @@ rules:
 
     no-console: warn
     no-warning-comments: warn
+    # Often gives false positives
+    require-atomic-updates: warn
 settings:
     html/indent: "+4"
     html/report-bad-indent: error

--- a/centralized.js
+++ b/centralized.js
@@ -1,0 +1,12 @@
+// Centralize some things so that a page only creates one instance of it.
+// This could be used for a shared audio context, for example.
+
+import {WorkerSpriteMaker} from './characters/sprites/worker-sprite-maker.js';
+
+let workerSpriteMaker;
+export function getWorkerSpriteMaker() {
+    if (!workerSpriteMaker) {
+        workerSpriteMaker = new WorkerSpriteMaker();
+    }
+    return workerSpriteMaker;
+}

--- a/characters/sprites/sprite-cache.js
+++ b/characters/sprites/sprite-cache.js
@@ -27,7 +27,11 @@ export class SpriteCache {
             throw new Error('Cache is full and cannot accept any more students.');
         }
         let spriteId = this.sprites++;
-        this._context.drawImage(sprite, spriteId * ENTRY_WIDTH, 0);
+        if (sprite instanceof ImageData) {
+            this._context.putImageData(sprite, spriteId * ENTRY_WIDTH, 0);
+        } else {
+            this._context.drawImage(sprite, spriteId * ENTRY_WIDTH, 0);
+        }
         return spriteId;
     }
 

--- a/characters/sprites/sprite-cache.js
+++ b/characters/sprites/sprite-cache.js
@@ -1,4 +1,4 @@
-import {SPRITE_WIDTH, SPRITE_HEIGHT, PICTURE_WIDTH, PICTURE_HEIGHT} from './sprite.js';
+import {SPRITE_WIDTH, SPRITE_HEIGHT, PICTURE_WIDTH, PICTURE_HEIGHT} from './sprite-constants.js';
 
 export class SpriteCache {
     constructor(capacity, type='sprite') {

--- a/characters/sprites/sprite-constants.js
+++ b/characters/sprites/sprite-constants.js
@@ -1,0 +1,26 @@
+const SPRITE_WIDTH = 12;
+const SPRITE_HEIGHT = 27;
+
+const PICTURE_WIDTH = 16;
+const PICTURE_HEIGHT = 16;
+
+let paths = [
+    'skin/skin', 'skin/shadow',
+    'pants/pants0', 'pants/pants1', 'shoes/shoes0', 'shoes/shoes1',
+    'shirt/shirt0', 'shirt/shirt1', 'shirt/shirt2',
+    'shirt/shirt3', 'shirt/shirt4', 'shirt/shirt5',
+    'hair/hair0/hair', 'hair/hair1/hair', 'hair/hair2/hair',
+    'hair/hair3/hair', 'hair/hair4/hair', 'hair/hair5/hair',
+    'hair/hair0/shadow', 'hair/hair1/shadow', 'hair/hair2/shadow',
+    'hair/hair3/shadow', 'hair/hair4/shadow', 'hair/hair5/shadow',
+    'hat/hat', 'hat/shadow',
+    'picture/picture'
+];
+
+export {
+    SPRITE_WIDTH,
+    SPRITE_HEIGHT,
+    PICTURE_WIDTH,
+    PICTURE_HEIGHT,
+    paths
+};

--- a/characters/sprites/sprite.js
+++ b/characters/sprites/sprite.js
@@ -1,8 +1,4 @@
-const SPRITE_WIDTH = 12; // leaving these here because Sean might use em
-const SPRITE_HEIGHT = 27; // these are the dimensions of the normal sprite, not the picture
-
-const PICTURE_WIDTH = 16;
-const PICTURE_HEIGHT = 16;
+import {SPRITE_WIDTH, SPRITE_HEIGHT, PICTURE_WIDTH, PICTURE_HEIGHT, paths} from './sprite-constants.js';
 
 let out = document.createElement('canvas');
 out.width = SPRITE_WIDTH;
@@ -14,18 +10,6 @@ pout.width = PICTURE_WIDTH;
 pout.height = PICTURE_HEIGHT;
 let pctx = pout.getContext('2d');
 
-let paths = [
-    'skin/skin', 'skin/shadow',
-    'pants/pants0', 'pants/pants1', 'shoes/shoes0', 'shoes/shoes1',
-    'shirt/shirt0', 'shirt/shirt1', 'shirt/shirt2',
-    'shirt/shirt3', 'shirt/shirt4', 'shirt/shirt5',
-    'hair/hair0/hair', 'hair/hair1/hair', 'hair/hair2/hair',
-    'hair/hair3/hair', 'hair/hair4/hair', 'hair/hair5/hair',
-    'hair/hair0/shadow', 'hair/hair1/shadow', 'hair/hair2/shadow',
-    'hair/hair3/shadow', 'hair/hair4/shadow', 'hair/hair5/shadow',
-    'hat/hat', 'hat/shadow',
-    'picture/picture'
-];
 let images = {};
 
 function loadImages() {

--- a/characters/sprites/sprite.worker.js
+++ b/characters/sprites/sprite.worker.js
@@ -7,6 +7,7 @@ const SPRITE_HEIGHT = 27;
 const PICTURE_WIDTH = 16;
 const PICTURE_HEIGHT = 16;
 
+let images;
 let ctx;
 
 function applyPixelFrom(target, source, {destX=0, destY=0, srcX=0, srcY=0}) {
@@ -127,3 +128,33 @@ function getSprite(sprite, picture=false) {
     }
     return ctx;
 }
+
+// From utils.js
+async function* receive(worker=self) {
+    let nextDone;
+    let next = [];
+    worker.addEventListener('message', ({data}) => {
+        nextDone(data);
+        next.push(new Promise(resolve => (nextDone = resolve)));
+    });
+    for (;;) {
+        yield await next.shift();
+    }
+}
+
+async function main() {
+    for (const {type, ...data} of receive()) {
+        switch (type) {
+            case 'images': {
+                images = data.data;
+                break;
+            }
+            case 'getSprite': {
+                self.postMessage(data.sprites.map(sprite => getSprite(sprite, data.picture)));
+                break;
+            }
+        }
+    }
+}
+
+main();

--- a/characters/sprites/sprite.worker.js
+++ b/characters/sprites/sprite.worker.js
@@ -30,7 +30,7 @@ function applyPixelFrom(target, source, {destX=0, destY=0, srcX=0, srcY=0}) {
         target.data[destIndex] = applyAlphaOverlay(target.data[destIndex], source.data[sourceIndex], opacity);
         target.data[destIndex + 1] = applyAlphaOverlay(target.data[destIndex + 1], source.data[sourceIndex + 1], opacity);
         target.data[destIndex + 2] = applyAlphaOverlay(target.data[destIndex + 2], source.data[sourceIndex + 2], opacity);
-        target.data[destIndex + 3] = Math.max(target.data[destIndex + 3], source.data[sourceIndex + 3])
+        target.data[destIndex + 3] = Math.max(target.data[destIndex + 3], source.data[sourceIndex + 3]);
     }
 }
 

--- a/characters/sprites/sprite.worker.js
+++ b/characters/sprites/sprite.worker.js
@@ -1,0 +1,129 @@
+// TODO: Unfortunately only Chrome supports module type workers. When we use
+// Rollup, I think we'll be able to import other JS files
+
+const SPRITE_WIDTH = 12;
+const SPRITE_HEIGHT = 27;
+
+const PICTURE_WIDTH = 16;
+const PICTURE_HEIGHT = 16;
+
+let ctx;
+
+function applyPixelFrom(target, source, {destX=0, destY=0, srcX=0, srcY=0}) {
+    let sourceIndex = (srcY * source.width + destX) * 4;
+    let destIndex = (destY * target.width + destX) * 4;
+    if (target[sourceIndex + 3] !== 0) {
+        target[destIndex] = target[sourceIndex];
+        target[destIndex + 1] = target[sourceIndex + 1];
+        target[destIndex + 2] = target[sourceIndex + 2];
+        target[destIndex + 3] = target[sourceIndex + 3];
+    }
+}
+
+function copyImageData(target, source, {
+    destX=0,
+    destY=0,
+    srcX=0,
+    srcY=0,
+    srcWidth=source.width,
+    srcHeight=source.height,
+    flipX=false
+}={}) {
+    for (let x = 0; x < srcWidth; x++) {
+        for (let y = 0; y < srcHeight; y++) {
+            setPixelFrom(target, source, {
+                destX: destX + x,
+                destY: destY + y,
+                srcX: srcX + (flipX ? srcWidth - 1 - x : x),
+                srcY: srcY + y
+            });
+        }
+    }
+}
+
+function drawTinted(image, y, facing, cuts) {
+    cuts.push(23);
+    for (let i = 0; i < cuts.length; i++) {
+        copyImageData(ctx, image, {
+            destX: 0,
+            destY: (cuts[i - 1] || 0) + y + i,
+            srcX: 0,
+            srcY: cuts[i - 1] || 0,
+            srcWidth: SPRITE_WIDTH,
+            srcHeight: cuts[i] - (cuts[i - 1] || 0) + 1,
+            flipX: facing === -1
+        });
+    }
+}
+
+function getSprite(sprite, picture=false) {
+    ctx = new ImageData(SPRITE_WIDTH, SPRITE_HEIGHT);
+
+    let cuts = [];
+    for (let i = 0; i < sprite.height; i++) {
+        cuts.push(i === sprite.height - 1 && i !== 0 ? 22 : 15);
+    }
+
+    drawTinted(images.skin, 3 - sprite.height, sprite.facing, cuts);
+    if (!picture) {
+        drawTinted(images['pants' + sprite.pants.type], 3 - sprite.height, sprite.facing, cuts);
+        drawTinted(images['shoes' + sprite.shoes.type], 3, sprite.facing, []);
+    }
+    drawTinted(images['shirt' + sprite.shirt.type], 3 - sprite.height, sprite.facing, cuts);
+    drawTinted(images.shadow, 3 - sprite.height, sprite.facing, cuts);
+    drawTinted(images['hair' + sprite.hair.type], 3 - sprite.height, sprite.facing, cuts);
+    drawTinted(images['hair' + sprite.hair.type + 's'], 3 - sprite.height, sprite.facing, cuts);
+
+    if (sprite.hat.type) {
+        drawTinted(images.hat, 3 - sprite.height, sprite.facing, []);
+        drawTinted(images.hats, 3 - sprite.height, sprite.facing, []);
+    }
+
+    for (let i = 0; i < gid.data.length; i += 4) {
+        let id = [];
+
+        // this method is so messy but it works
+        if (gid.data[i] + gid.data[i + 1] + gid.data[i + 2] === 0 || gid.data[i + 3] === 0) {
+            // #000 (eyes and mouth) or transparent
+            gid.data[i] = 102;
+            id = ['skin', 0];
+        } else if (gid.data[i] === 51) { // #333 (hat mask)
+            gid.data[i + 3] = 0; // erase pixels
+            continue;
+        } else if (gid.data[i] === gid.data[i + 1]) {
+            if (gid.data[i] === gid.data[i + 2]) { // #xxx (hat)
+                id = ['hat', 0];
+            } else if (gid.data[i + 2] === 0) { // #xx0 (pants)
+                id = ['pants', 0];
+            } else { // #00x (shirt 2)
+                id = ['shirt', 2, 1];
+            }
+        } else if (gid.data[i] === gid.data[i + 2]) {
+            if (gid.data[i + 1] === 0) { // #x0x (hair)
+                id = ['hair', 0];
+            } else { // #0x0 (shoes)
+                id = ['shoes', 1];
+            }
+        } else {
+            if (gid.data[i] === 0) { // #0xx (shirt 1)
+                id = ['shirt', 1, 0];
+            } else { // #x00 (skin)
+                id = ['skin', 0];
+            }
+        }
+
+        let rgb = sprite[id[0]].tint[id[2] ? id[2] : 0];
+        let base = gid.data[i + id[1]];
+        gid.data[i] = Math.max(0, rgb[0] - (255 - base));
+        gid.data[i + 1] = Math.max(0, rgb[1] - (255 - base));
+        gid.data[i + 2] = Math.max(0, rgb[2] - (255 - base));
+    }
+
+    if (picture) {
+        let pctx = new ImageData(PICTURE_WIDTH, PICTURE_HEIGHT);
+        copyImageData(pctx, images.picture);
+        copyImageData(pctx, ctx, {destX: 2, destY: 0});
+        return pctx;
+    }
+    return ctx;
+}

--- a/characters/sprites/worker-sprite-maker.js
+++ b/characters/sprites/worker-sprite-maker.js
@@ -1,0 +1,44 @@
+import {SPRITE_WIDTH, SPRITE_HEIGHT, PICTURE_WIDTH, PICTURE_HEIGHT, paths} from './sprite-constants.js';
+import {loadImage} from '../../cocnept-designs/sean/canvas-stuff.js';
+import {receive} from '../../utils.js';
+
+function loadImageData() {
+    let canvas = document.createElement('canvas');
+    let c = canvas.getContext('2d');
+    return Promise.all(paths.map(path =>
+        loadImage(new URL(`./images/student/${path}.png`, import.meta.url))
+            .then(image => {
+                let split = path.split('/');
+                let code = split[1];
+                if (split[2]) {
+                    code += split[2] === 'shadow' ? 's' : '';
+                } else if (split[0] === 'hat') {
+                    code = 'hat' + (split[1] === 'shadow' ? 's' : '');
+                }
+
+                canvas.width = image.width;
+                canvas.height = image.height;
+                c.drawImage(image, 0, 0);
+                return [code, c.getImageData(0, 0, canvas.width, canvas.height)];
+            })))
+        .then(data => {
+            return Object.fromEntries(data);
+        });
+}
+
+export class WorkerSpriteMaker {
+    constructor() {
+        this.worker = new Worker(new URL('./sprite.worker.js', import.meta.url));
+        this.receiver = receive(this.worker);
+
+        this.ready = loadImageData().then(data => {
+            this.worker.postMessage({type: 'images', data});
+        });
+    }
+
+    async getSprites(sprites, picture=false) {
+        this.worker.postMessage({type: 'getSprite', sprites, picture});
+        let {value} = await this.receiver.next();
+        return value;
+    }
+}

--- a/characters/sprites/worker-sprite-maker.js
+++ b/characters/sprites/worker-sprite-maker.js
@@ -37,6 +37,7 @@ export class WorkerSpriteMaker {
     }
 
     async getSprites(sprites, picture=false) {
+        await this.ready;
         this.worker.postMessage({type: 'getSprite', sprites, picture});
         let {value} = await this.receiver.next();
         return value;

--- a/characters/sprites/worker-sprite-maker.js
+++ b/characters/sprites/worker-sprite-maker.js
@@ -1,4 +1,4 @@
-import {SPRITE_WIDTH, SPRITE_HEIGHT, PICTURE_WIDTH, PICTURE_HEIGHT, paths} from './sprite-constants.js';
+import {paths} from './sprite-constants.js';
 import {loadImage} from '../../cocnept-designs/sean/canvas-stuff.js';
 import {receive} from '../../utils.js';
 

--- a/cocnept-designs/sean/students-roam.js
+++ b/cocnept-designs/sean/students-roam.js
@@ -1,7 +1,8 @@
 import {WrappedCanvas, loadImage} from './canvas-stuff.js';
 import {Panner} from './panner.js';
 
-import {WIDTH, HEIGHT, loadImages, getSprite} from '../../characters/sprites/sprite.js';
+import {SPRITE_WIDTH, SPRITE_HEIGHT} from '../../characters/sprites/sprite-constants.js';
+import {WorkerSpriteMaker} from '../../characters/sprites/worker-sprite-maker.js';
 import {randomSprite} from '../../characters/sprites/random-sprite.js';
 import {SpriteCache} from '../../characters/sprites/sprite-cache.js';
 
@@ -135,7 +136,7 @@ class Student {
             x += (next.x - x) * progress;
             y += (next.y - y) * progress;
         }
-        y += 0.5 - HEIGHT / WIDTH;
+        y += 0.5 - SPRITE_HEIGHT / SPRITE_WIDTH;
         this.visual = {x, y};
     }
 }
@@ -168,7 +169,7 @@ export default async function main(wrapper, debug=false) {
         const selectX = (clientX - wrappedCanvas.x - transform.offsetX) / transform.scale - leftPadding;
         const selectY = (clientY - wrappedCanvas.y - transform.offsetY) / transform.scale - topPadding;
         const width = 1;
-        const height = HEIGHT / WIDTH;
+        const height = SPRITE_HEIGHT / SPRITE_WIDTH;
         return students
             .filter(({visual: {x, y}}) => {
                 return inRange(selectX, {min: x, max: x + width}) &&
@@ -222,10 +223,10 @@ export default async function main(wrapper, debug=false) {
         students.sort((a, b) => a.visual.y - b.visual.y);
         c.lineWidth = 0.05;
         for (let {spriteId, visual: {x, y}, lastTouched} of students) {
-            spriteCache.draw(c, spriteId, x, y, 1, HEIGHT / WIDTH);
+            spriteCache.draw(c, spriteId, x, y, 1, SPRITE_HEIGHT / SPRITE_WIDTH);
             if (now - lastTouched < 200) {
                 c.strokeStyle = `rgba(255, 0, 0, ${1 - (now - lastTouched) / 200})`;
-                c.strokeRect(x, y, 1, HEIGHT / WIDTH);
+                c.strokeRect(x, y, 1, SPRITE_HEIGHT / SPRITE_WIDTH);
             }
         }
 
@@ -237,14 +238,14 @@ export default async function main(wrapper, debug=false) {
         if (ready) paint();
     });
 
-    let [background] = await Promise.all([
+    let [background, spriteData] = await Promise.all([
         loadImage(new URL('./campus.png', import.meta.url)),
-        wrappedCanvas.resize(),
-        loadImages()
+        new WorkerSpriteMaker().getSprites(students.map(() => randomSprite())),
+        wrappedCanvas.resize()
     ]);
 
-    for (let student of students) {
-        student.spriteId = spriteCache.add(getSprite(randomSprite()));
+    for (let i = 0; i < students.length; i++) {
+        students[i].spriteId = spriteCache.add(spriteData[i]);
     }
 
     if (debug) {

--- a/cocnept-designs/sean/students-roam.js
+++ b/cocnept-designs/sean/students-roam.js
@@ -2,7 +2,7 @@ import {WrappedCanvas, loadImage} from './canvas-stuff.js';
 import {Panner} from './panner.js';
 
 import {SPRITE_WIDTH, SPRITE_HEIGHT} from '../../characters/sprites/sprite-constants.js';
-import {WorkerSpriteMaker} from '../../characters/sprites/worker-sprite-maker.js';
+import {getWorkerSpriteMaker} from '../../centralized.js';
 import {randomSprite} from '../../characters/sprites/random-sprite.js';
 import {SpriteCache} from '../../characters/sprites/sprite-cache.js';
 
@@ -240,7 +240,7 @@ export default async function main(wrapper, debug=false) {
 
     let [background, spriteData] = await Promise.all([
         loadImage(new URL('./campus.png', import.meta.url)),
-        new WorkerSpriteMaker().getSprites(students.map(() => randomSprite())),
+        getWorkerSpriteMaker().getSprites(students.map(() => randomSprite())),
         wrappedCanvas.resize()
     ]);
 

--- a/cocnept-designs/v2/directory.js
+++ b/cocnept-designs/v2/directory.js
@@ -70,14 +70,13 @@ class DirectoryItem {
         return this;
     }
 
-    setStudent(student, selected=false) {
+    setStudent(pictureCache, student, selected=false) {
         let {wrapper, ctx, name, info} = this._elems;
         if (this.student !== student) {
             this.student = student;
 
             wrapper.id = student.id;
-            // TODO: Cache student pictures
-            ctx.drawImage(getSprite(student.picture, true), 0, 0, PICTURE_WIDTH, PICTURE_HEIGHT);
+            pictureCache.draw(ctx, student.pictureId);
             name.innerHTML = `${student.name.last}, ${student.name.first}`;
             let disgrade = student.grade === 9 ? '09' : student.grade;
             info.innerHTML = `Grade ${disgrade} | ${student.gender} | <span class="sstatus">Enrolled</span>`;
@@ -118,14 +117,17 @@ const ITEM_PADDING = 2;
  * Recycles DirectoryItems as the user scrolls to limit the number of elements.
  */
 class Directory {
-    constructor(wrapper, students=[]) {
+    constructor(wrapper) {
         bindMethods(this, [
             'updateScroll',
             '_onItemClicked'
         ]);
 
         this.wrapper = wrapper;
-        this.students = students;
+
+        // These need to be set
+        this.pictureCache = null;
+        this.students = [];
 
         // The student object of the selected item (NOT a DirectoryItem)
         this.selected = null;
@@ -215,7 +217,7 @@ class Directory {
             // Move a recycleable to the unclaimed position
             let recycleable = recycleables.pop();
             recycleable
-                .setStudent(this.students[y], this.students[y] === this.selected)
+                .setStudent(this.pictureCache, this.students[y], this.students[y] === this.selected)
                 .addTo(this.wrapper)
                 .wrapper.style.top = y * ITEM_HEIGHT + 'px';
             this._items.set(y, recycleable);

--- a/cocnept-designs/v2/directory.js
+++ b/cocnept-designs/v2/directory.js
@@ -1,5 +1,5 @@
 import {bindMethods} from '../../utils.js';
-import {PICTURE_WIDTH, PICTURE_HEIGHT, getSprite} from '../../characters/sprites/sprite.js';
+import {PICTURE_WIDTH, PICTURE_HEIGHT} from '../../characters/sprites/sprite-constants.js';
 
 /**
  * Represents a DOM element in the directory.

--- a/cocnept-designs/v2/index.html
+++ b/cocnept-designs/v2/index.html
@@ -363,7 +363,8 @@
         <script type="module">
             import * as SCHOOL from '../../school/school.js';
             import * as SCHEDULE from '../../school/schedule.js';
-            import * as SPRITES from '../../characters/sprites/sprite.js';
+            import {SpriteCache} from '../../characters/sprites/sprite-cache.js';
+            import {getWorkerSpriteMaker} from '../../centralized.js';
             import {Directory} from './directory.js';
 
             // Toggle panel buttons for small screen
@@ -406,14 +407,23 @@
 
             // Student directory
             let school;
+            let pictureCache;
             let directoryList = new Directory(document.getElementById('list'));
 
             async function dewit() {
-                await SPRITES.loadImages();
                 school = await SCHOOL.generateSchool();
                 SCHEDULE.generateSchedule(school);
 
                 school.Students.sort((x, y) => x.name.last.localeCompare(y.name.last));
+
+                // Generate and cache student pictures
+                pictureCache = new SpriteCache(school.Students.length, 'picture');
+                let pictures = await getWorkerSpriteMaker()
+                    .getSprites(school.Students.map(student => student.picture), true);
+                for (let i = 0; i < school.Students.length; i++) {
+                    school.Students[i].pictureId = pictureCache.add(pictures[i]);
+                }
+                directoryList.pictureCache = pictureCache;
 
                 directoryList.students = [...school.Students];
                 directoryList.updateData();

--- a/utils.js
+++ b/utils.js
@@ -37,12 +37,17 @@ export function inRange(num, {min=-Infinity, max=Infinity}={}) {
     return num >= min && num <= max;
 }
 
-export async function* receive(data, worker=self) {
+// Has a copy in sprite.worker.js
+export async function* receive(worker=self) {
     let nextDone;
     let next = [];
-    worker.addEventListener('message', e => {
-        nextDone();
+    function newNext() {
         next.push(new Promise(resolve => (nextDone = resolve)));
+    }
+    newNext();
+    worker.addEventListener('message', ({data}) => {
+        nextDone(data);
+        newNext();
     });
     for (;;) {
         yield await next.shift();

--- a/utils.js
+++ b/utils.js
@@ -36,3 +36,15 @@ export function HSVtoRGB(h, s, v) {
 export function inRange(num, {min=-Infinity, max=Infinity}={}) {
     return num >= min && num <= max;
 }
+
+export async function* receive(data, worker=self) {
+    let nextDone;
+    let next = [];
+    worker.addEventListener('message', e => {
+        nextDone();
+        next.push(new Promise(resolve => (nextDone = resolve)));
+    });
+    for (;;) {
+        yield await next.shift();
+    }
+}


### PR DESCRIPTION
Fixes #47 

I've moved sprite image creation into the web worker. Web workers only have access to OffscreenCanvas, which Safari does not support, so instead it deals with ImageData directly since it can be passed over `postMessage`.

Here is the performance graph for v2:
![image](https://user-images.githubusercontent.com/22133785/82108302-7781ec00-96e2-11ea-9d34-70348fa8930c.png)
You can see that `generateSchool` takes quite some time, during which nothing else can happen on the page. For weaker devices, this might freeze the page long enough to bring up the scary "This page isn't responding" dialogue.

Generating all the picture and sprite images (below) is now done in a web worker, which won't freeze the page. Pretty epic. However, module type web workers are only supported in Chrome, so it can't import the `generateSchool` code. That's also why `sprite.worker.js` has basically the same sprite generation code but without `import` statements

Hopefully when we get Rollup it can produce files for workers so we can use import in web workers

This pull request is also linted

This also creates a `centralized.js` file so that only one instance of things is created per page, which could be useful for WorkerSpriteMakers (in this PR) and audio contexts if we ever need them