### PR TITLE
Integrate intro into v2

### DIFF
--- a/centralized.js
+++ b/centralized.js
@@ -10,3 +10,11 @@ export function getWorkerSpriteMaker() {
     }
     return workerSpriteMaker;
 }
+
+let params;
+export function param(key) {
+    if (!params) {
+        params = new URL(window.location).searchParams;
+    }
+    return params.get(key);
+}

--- a/cocnept-designs/sean/intro.css
+++ b/cocnept-designs/sean/intro.css
@@ -1,3 +1,8 @@
+.intro-mode {
+    justify-content: center;
+    align-items: center;
+}
+
 .intro {
     padding: 20px;
     box-sizing: border-box;

--- a/cocnept-designs/sean/intro.html
+++ b/cocnept-designs/sean/intro.html
@@ -11,14 +11,9 @@
 
       @import url('./dialogue.css');
       @import url('./intro.css');
-
-      body {
-        justify-content: center;
-        align-items: center;
-      }
     </style>
   </head>
-  <body>
+  <body class="intro-mode">
     <script type="module">
         import '../focus-visible.js';
 

--- a/cocnept-designs/sean/principal-demo.css
+++ b/cocnept-designs/sean/principal-demo.css
@@ -7,6 +7,9 @@
 
 .principal-demo {
     position: fixed;
+    top: 0;
+    left: 0;
+    z-index: 10;
     display: flex;
     align-items: center;
     max-width: 500px;

--- a/cocnept-designs/sean/principal-demo.json
+++ b/cocnept-designs/sean/principal-demo.json
@@ -1,4 +1,11 @@
 [
+    {
+        "special": {
+            "type": "set-thumbnail",
+            "image-id": "principal",
+            "color": "#d1efea"
+        }
+    },
     "You’ll be working here.",
     {
       "say": "This is the camera. You can click on students and our advanced facial recognition software will identify potential matches.",

--- a/cocnept-designs/title/index.html
+++ b/cocnept-designs/title/index.html
@@ -203,10 +203,10 @@
                 await SCHOOL.getNames(); //note: this loads names which are currently not needed
                 await SPRITES.loadImages(); //note: this loads hats, pants, and shoes which are not needed
                 //this contributes to it taking like 2 secs to load (for me), but i'm too lazy to fix so
-
+                
                 document.getElementById('container').style.display = 'initial';
                 let canvases = document.getElementsByTagName('canvas');
-
+                
                 for (let i = 0; i < canvases.length; i++) {
                     canvases[i].style.width = '100px';
                     canvases[i].style.height = '100px';
@@ -229,7 +229,7 @@
             function getOut() {
                 document.getElementById('title').children[0].style.color = '#333';
                 let papers = document.getElementsByClassName('paper'); //papers please!
-
+                
                 if (time === -50) {
                     for (let i = 0; i < papers.length; i++) {
                         papers[i].style.filter = 'invert(1)';

--- a/cocnept-designs/title/index.html
+++ b/cocnept-designs/title/index.html
@@ -13,7 +13,7 @@
                 background-color: #000;
                 height: 100%;
             }
-            
+
             #container {
                 display: none;
                 position: fixed;
@@ -182,7 +182,7 @@
                 </div>
             </div>
         </div>
-        
+
         <script type="module">
             function rescale() {
                 let container = document.getElementById('container');
@@ -194,19 +194,19 @@
             } rescale();
             window.onresize = function () {rescale();}
         </script>
-        
+
         <script type="module">
             import * as SCHOOL from '../../school/school.js';
             import * as SPRITES from '../../characters/sprites/sprite.js';
-            
+
             async function doStuff() {
                 await SCHOOL.getNames(); //note: this loads names which are currently not needed
                 await SPRITES.loadImages(); //note: this loads hats, pants, and shoes which are not needed
                 //this contributes to it taking like 2 secs to load (for me), but i'm too lazy to fix so
-                
+
                 document.getElementById('container').style.display = 'initial';
                 let canvases = document.getElementsByTagName('canvas');
-                
+
                 for (let i = 0; i < canvases.length; i++) {
                     canvases[i].style.width = '100px';
                     canvases[i].style.height = '100px';
@@ -218,18 +218,18 @@
                     ctx.drawImage(SPRITES.getSprite(SCHOOL.randomStudent().picture, true), 0, 0, 100, 100);
                 }
             }
-            
+
             doStuff();
         </script>
         <script>
             let time = -50;
             let left = [];
             let total = 0;
-            
+
             function getOut() {
                 document.getElementById('title').children[0].style.color = '#333';
                 let papers = document.getElementsByClassName('paper'); //papers please!
-                
+
                 if (time === -50) {
                     for (let i = 0; i < papers.length; i++) {
                         papers[i].style.filter = 'invert(1)';
@@ -237,9 +237,9 @@
                     }
                     total = left.length;
                 }
-                
+
                 time++;
-                
+
                 if (time % 3 === 0 && time > 0) {
                     document.getElementById('title').style.opacity = 1 - Math.pow(time / 3 / total, 2);
                     let choose = Math.floor(Math.random() * left.length);
@@ -247,11 +247,13 @@
 
                     left.splice(choose, 1);
                 }
-                
+
                 if (time / 3 < total) {
                     window.requestAnimationFrame(getOut);
                 } else {
                     // go to next page
+                    // TEMP?
+                    window.location = '../v2/';
                 }
             }
         </script>

--- a/cocnept-designs/title/index.html
+++ b/cocnept-designs/title/index.html
@@ -13,7 +13,7 @@
                 background-color: #000;
                 height: 100%;
             }
-
+            
             #container {
                 display: none;
                 position: fixed;
@@ -182,7 +182,7 @@
                 </div>
             </div>
         </div>
-
+        
         <script type="module">
             function rescale() {
                 let container = document.getElementById('container');
@@ -194,11 +194,11 @@
             } rescale();
             window.onresize = function () {rescale();}
         </script>
-
+        
         <script type="module">
             import * as SCHOOL from '../../school/school.js';
             import * as SPRITES from '../../characters/sprites/sprite.js';
-
+            
             async function doStuff() {
                 await SCHOOL.getNames(); //note: this loads names which are currently not needed
                 await SPRITES.loadImages(); //note: this loads hats, pants, and shoes which are not needed
@@ -218,14 +218,14 @@
                     ctx.drawImage(SPRITES.getSprite(SCHOOL.randomStudent().picture, true), 0, 0, 100, 100);
                 }
             }
-
+            
             doStuff();
         </script>
         <script>
             let time = -50;
             let left = [];
             let total = 0;
-
+            
             function getOut() {
                 document.getElementById('title').children[0].style.color = '#333';
                 let papers = document.getElementsByClassName('paper'); //papers please!
@@ -237,9 +237,9 @@
                     }
                     total = left.length;
                 }
-
+                
                 time++;
-
+                
                 if (time % 3 === 0 && time > 0) {
                     document.getElementById('title').style.opacity = 1 - Math.pow(time / 3 / total, 2);
                     let choose = Math.floor(Math.random() * left.length);
@@ -247,7 +247,7 @@
 
                     left.splice(choose, 1);
                 }
-
+                
                 if (time / 3 < total) {
                     window.requestAnimationFrame(getOut);
                 } else {

--- a/cocnept-designs/v2/index.html
+++ b/cocnept-designs/v2/index.html
@@ -365,7 +365,7 @@
             import * as SCHOOL from '../../school/school.js';
             import * as SCHEDULE from '../../school/schedule.js';
             import {SpriteCache} from '../../characters/sprites/sprite-cache.js';
-            import {getWorkerSpriteMaker} from '../../centralized.js';
+            import {getWorkerSpriteMaker, param} from '../../centralized.js';
             import {Directory} from './directory.js';
             import {Dialogue} from '../sean/dialogue.js';
 
@@ -511,7 +511,7 @@
             new Image().src = '../sean/munkler.png';
             new Image().src = '../../characters/sprites/images/munkler/sprite.png';
 
-            dewit().then(() => intro(() => {
+            function showUI() {
                 document.body.classList.remove('intro-mode');
                 return Promise.all([
                     directoryList.resize()
@@ -522,8 +522,17 @@
                         main(document.getElementById('camvis'));
                     })
                 ]);
-            })).then(async data => {
-                console.log(data);
+            }
+
+            dewit().then(() => {
+                if (param('skip-intro')) {
+                    showUI();
+                    return 'intro skipped';
+                } else {
+                    return intro(showUI);
+                }
+            }).then(data => {
+                // Do something with whatever the user put for the name
             });
         </script>
     </body>

--- a/cocnept-designs/v2/index.html
+++ b/cocnept-designs/v2/index.html
@@ -238,27 +238,27 @@
                         </div>
                     </div>
                     <div id="camdetect">
-                        <div class="student">
+                        <div class="camstudent">
                             <div class="spic"></div>
                             <p class="sname">Munkler,<br>Leuf</p>
                         </div>
-                        <div class="student">
+                        <div class="camstudent">
                             <div class="spic"></div>
                             <p class="sname">Munkler,<br>Leuf</p>
                         </div>
-                        <div class="student">
+                        <div class="camstudent">
                             <div class="spic"></div>
                             <p class="sname">Munkler,<br>Leuf</p>
                         </div>
-                        <div class="student">
+                        <div class="camstudent">
                             <div class="spic"></div>
                             <p class="sname">Munkler,<br>Leuf</p>
                         </div>
-                        <div class="student">
+                        <div class="camstudent">
                             <div class="spic"></div>
                             <p class="sname">Munkler,<br>Leuf</p>
                         </div>
-                        <div class="student">
+                        <div class="camstudent">
                             <div class="spic"></div>
                             <p class="sname">Munkler,<br>Leuf</p>
                         </div>

--- a/cocnept-designs/v2/index.html
+++ b/cocnept-designs/v2/index.html
@@ -8,7 +8,7 @@
         <link href="styles.css" rel="stylesheet">
     </head>
 
-    <body>
+    <body class="intro-mode">
         <div id="container">
             <div class="screen" id="s-menu" data-change-menu="unmenu"></div>
             <div id="menu" class="outlined modal">
@@ -367,6 +367,38 @@
             import {SpriteCache} from '../../characters/sprites/sprite-cache.js';
             import {getWorkerSpriteMaker} from '../../centralized.js';
             import {Directory} from './directory.js';
+            import {Dialogue} from '../sean/dialogue.js';
+
+            async function intro(showUI) {
+                const introData = fetch('./intro-dialogue.json').then(r => r.json());
+                const demoData = fetch('../sean/principal-demo.json').then(r => r.json());
+
+                const intro = new Dialogue({wrapperClass: 'intro'});
+                const demo = new Dialogue({
+                    measureHeight: false,
+                    wrapperClass: 'principal-demo'
+                });
+
+                await introData; // Wait for intro data to load first
+                const data = await intro.addTo(document.body)
+                    .start(await introData, {
+                        intro: '../sean/munkler.png',
+                        principal: '../../characters/sprites/images/munkler/sprite.png'
+                    });
+                intro.removeFromParent();
+
+                await showUI();
+
+                // The part where the principal introduces parts of the UI
+                await demo.addTo(document.body)
+                    .start(await demoData, {
+                        principal: '../../characters/sprites/images/munkler/sprite.png'
+                    });
+                demo.removeFromParent();
+
+                // TODO: Do something with whatever the player drew?
+                return data;
+            }
 
             // Toggle panel buttons for small screen
             let togglePanelBtns = document.getElementsByClassName('toggle-panel-btn');
@@ -428,8 +460,6 @@
 
                 directoryList.students = [...school.Students];
                 directoryList.updateData();
-                await directoryList.resize();
-                directoryList.updateScroll();
             }
 
             function search(name) {
@@ -469,8 +499,6 @@
 
             switchScreen('game');
             changeMenu('unmenu');
-
-            dewit();
             displaySchedule();
 
             const searchInput = document.getElementById('search');
@@ -478,11 +506,25 @@
                 search(searchInput.value);
             });
 
-            // Show the camera footage and principal intro demo
-            // Using dynamic import so that it runs after switchScreen('game')
-            // without which would have both showing and making the measured
-            // height less than is actually lol
-            import('../sean/injection.js');
+            // Preload sprites
+            // https://stackoverflow.com/questions/3646036/preloading-images-with-javascript
+            new Image().src = '../sean/munkler.png';
+            new Image().src = '../../characters/sprites/images/munkler/sprite.png';
+
+            dewit().then(() => intro(() => {
+                document.body.classList.remove('intro-mode');
+                return Promise.all([
+                    directoryList.resize()
+                        .then(() => directoryList.updateScroll()),
+
+                    // TEMP: Show the camera footage (demo?)
+                    import('../sean/students-roam.js').then(({default: main}) => {
+                        main(document.getElementById('camvis'));
+                    })
+                ]);
+            })).then(async data => {
+                console.log(data);
+            });
         </script>
     </body>
 </html>

--- a/cocnept-designs/v2/intro-dialogue.json
+++ b/cocnept-designs/v2/intro-dialogue.json
@@ -1,0 +1,36 @@
+[
+    {
+        "special": {
+            "type": "set-thumbnail",
+            "image-id": "intro",
+            "color": "#ebdeae"
+        }
+    },
+    {
+        "say": "It’s a beautiful day in Thick Stick City. Are you ready for your new job at Harry Cannon High School?",
+        "options": {
+            "Yes": "Well that’s great! You’d better get moving along then. What an amazing opportunity this is.",
+            "No": "Well that’s too bad. But the bills don’t pay themselves, especially with the rent so high here! Why did you get this job anyway?"
+        }
+    },
+    "It’s your first day working as a tech guy for Cannon H.S., so you’ll probably want to write your name on this sticker.",
+    {
+        "special": {
+            "type": "canvas",
+            "saveTo": "name"
+        }
+    },
+    "Oh, erm... You know, do you mind if I call you tech guy?",
+    "Great! Let’s go suspend some students!",
+
+    {
+        "special": {
+            "type": "set-thumbnail",
+            "image-id": "principal",
+            "color": "#d1efea"
+        }
+    },
+    "Hello there, uh... And welcome to Cannon H.S. As this year’s principal, let me tell you how this is going to work.",
+    "We here at Cannon are dedicated to making a safe and amazing learning environment for our pupils and thus, have installed cameras around the school to ensure everything runs smoothly.",
+    "Your job is to catch bad pupils who disrupt our learning environment."
+]

--- a/cocnept-designs/v2/styles.css
+++ b/cocnept-designs/v2/styles.css
@@ -1,4 +1,9 @@
 @import url('../game.css');
+@import url('../basic-flex.css');
+
+@import url('../sean/dialogue.css');
+@import url('../sean/intro.css');
+@import url('../sean/principal-demo.css');
 
 .modal {
     background-color: #000;
@@ -85,6 +90,10 @@
     /* Prevent the overflow when it does the slidey thing on small screens from
     making the device zoom out, si me entiendes. */
     overflow-x: hidden;
+}
+/* Hide the main UI during the intro */
+.intro-mode #container {
+    display: none;
 }
 
 #controls {

--- a/cocnept-designs/v2/styles.css
+++ b/cocnept-designs/v2/styles.css
@@ -199,7 +199,7 @@
     bottom: 10px; left: 10px; right: 10px;
     z-index: 1;
 }
-#camdetect .student {
+.camstudent {
     border: none;
     margin: 0 20px 0 0;
     padding: 0;

--- a/utils.js
+++ b/utils.js
@@ -14,21 +14,51 @@ export function frame() {
 
 export function vary(color, hdeg, bdeg) {
     let brand = Math.random() * (bdeg * 2 + 1) - bdeg;
-    return [Math.min(Math.max(color[0] + Math.random() * (hdeg * 2 + 1) - hdeg + brand, 0), 255),
-            Math.min(Math.max(color[1] + Math.random() * (hdeg * 2 + 1) - hdeg + brand, 0), 255),
-            Math.min(Math.max(color[2] + Math.random() * (hdeg * 2 + 1) - hdeg + brand, 0), 255)]
+    return [
+        Math.min(Math.max(color[0] + Math.random() * (hdeg * 2 + 1) - hdeg + brand, 0), 255),
+        Math.min(Math.max(color[1] + Math.random() * (hdeg * 2 + 1) - hdeg + brand, 0), 255),
+        Math.min(Math.max(color[2] + Math.random() * (hdeg * 2 + 1) - hdeg + brand, 0), 255)
+    ];
 }
 
 export function HSVtoRGB(h, s, v) {
-    var r, g, b, i, f, p, q, t;
-    i = Math.floor(h * 6); f = h * 6 - i; p = v * (1 - s); q = v * (1 - f * s); t = v * (1 - (1 - f) * s);
+    let r, g, b, i, f, p, q, t;
+    i = Math.floor(h * 6);
+    f = h * 6 - i;
+    p = v * (1 - s);
+    q = v * (1 - f * s);
+    t = v * (1 - (1 - f) * s);
     switch (i % 6) {
-        case 0: r = v, g = t, b = p; break;
-        case 1: r = q, g = v, b = p; break;
-        case 2: r = p, g = v, b = t; break;
-        case 3: r = p, g = q, b = v; break;
-        case 4: r = t, g = p, b = v; break;
-        case 5: r = v, g = p, b = q; break;
+        case 0:
+            r = v;
+            g = t;
+            b = p;
+            break;
+        case 1:
+            r = q;
+            g = v;
+            b = p;
+            break;
+        case 2:
+            r = p;
+            g = v;
+            b = t;
+            break;
+        case 3:
+            r = p;
+            g = q;
+            b = v;
+            break;
+        case 4:
+            r = t;
+            g = p;
+            b = v;
+            break;
+        case 5:
+            r = v;
+            g = p;
+            b = q;
+            break;
     }
     return [Math.floor(r * 255), Math.floor(g * 255), Math.floor(b * 255)];
 }


### PR DESCRIPTION
Seeing that #52 is happening, I've moved the intro into v2. This also eliminates the need for the hacky `injection.js` that was only for testing purposes

This doesn't make it completely independent of cocnept-designs/sean/ though; many of the files within are still being used (but can be moved out when #52 is implemented):
![List of files used in the sean directory](https://user-images.githubusercontent.com/22133785/82136366-14678680-97c2-11ea-92a6-af40f5081d31.png)
Some of the files in there are only for demonstration purposes though (namely, `munkler.png`, `campus.png`, and `students-roam.js`)

I've also added support for a temporary URL flag to skip the intro for development purposes; adding `?skip-intro=yes` to the URL will make it not show the intro